### PR TITLE
Fix title not sticking with content when `breakable` is enabled

### DIFF
--- a/src/thmbox.typ
+++ b/src/thmbox.typ
@@ -142,6 +142,7 @@
         block(
           above: 0em,
           below: 1.2em,
+          sticky: true
         )[
           #set text(font: title-fonts, color, weight: "bold")
           #let counter-display = if numbering != none {


### PR DESCRIPTION
Before:
![2025-06-02-175901_hyprshot](https://github.com/user-attachments/assets/c47fe8d9-a508-4ce3-9ec7-8a1f9a292aee)

After the fix:
![2025-06-02-180028_hyprshot](https://github.com/user-attachments/assets/022f7981-28d6-4b52-b8fb-808b9e2f401d)

