### PR TITLE
Update section on `breakable` in README to only modify thmboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The recommended font for documents using this package is New Computer Modern (sh
 
 The recommended sans-serif font (can be changed with the `sans-fonts` and `title-fonts` parameter) is New Computer Modern Sans (download at [CTAN](https://ctan.org/pkg/newcomputermodern))
 
-By default, thmboxes don't break across pages. To enable that, you can use the rule `#show figure: set block(breakable: true)`. Other `set` and `show` rules for figures can be used with thmboxes as well, as figures are used under the hood.
+By default, thmboxes don't break across pages. To enable that, you can use the rule `#show figure.where(kind: "thmbox"): set block(breakable: true)`. Other `set` and `show` rules for figures can be used with thmboxes as well, as figures are used under the hood.
 
 ## Installation
 


### PR DESCRIPTION
The rule `#show figure: set block(breakable: true)` given in the README applies to all figures.
It should be restricted to thmboxes.