### PR TITLE
Update QED symbol

### DIFF
--- a/src/thmbox.typ
+++ b/src/thmbox.typ
@@ -183,7 +183,7 @@
   h(1fr)
   context { 
     set text(size: 0.8 * text.size)
-    "☐"
+    "□"
   }
 }
 


### PR DESCRIPTION
The QED symbol used seems to be non-standard and is not rendered properly locally:
<img width="35" height="23" alt="image" src="https://github.com/user-attachments/assets/b1bfad6d-8f55-4f51-bf9e-da0b6b35cb5b" />
This PR changes the Unicode symbol to a more standard one, enabling proper rendering on MacOS.